### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.12 as build
+
+ARG GO111MODULE=on
+ARG CGO_ENABLED=0
+ARG GOOS=linux
+ARG GOARCH=amd64
+
+WORKDIR /go/src/app
+COPY . ./
+
+RUN go build \
+    -a \
+    -tags netgo \
+    -ldflags '-w -extldflags "-static"' \
+    -o apcupsd_exporter \
+    cmd/apcupsd_exporter/main.go
+
+FROM scratch
+COPY --from=build /go/src/app/apcupsd_exporter /
+
+EXPOSE 9162
+ENTRYPOINT [ "/apcupsd_exporter" ]


### PR DESCRIPTION
Hey Matt! I thought it might be a good idea to add a simple Dockerfile to create a containerized version of the apcupsd_exporter. Thanks to using `FROM scratch`, the final image comes in at less than 9MiB.

I hope this contribution is welcome and let me know if there's anything you'd like to see changed.

Cheers! 👋 