### PR TITLE
Have GHA build the binaries

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,38 @@
+# See: https://github.com/wangyoucao577/go-release-action
+# See: https://github.com/marketplace/actions/go-release-binaries
+##
+on:
+  release:
+    types: [created]
+
+  # See: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+  workflow_dispatch:
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, linux/arm, darwin/amd64, darwin/arm64
+        ##
+        #  GOOS=linux GOARCH=arm
+        goos: [linux, darwin]
+        goarch: ["386", amd64, arm64, arm]
+        exclude:
+          # No 32 bit intel or ARM builds for macOS platforms
+          - goarch: "386"
+            goos: darwin
+          - goarch: "arm"
+            goos: darwin
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wangyoucao577/go-release-action@v1.29
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: 1.17
+          # Publish sha hashes, not md5
+          md5sum: false
+          sha256sum: true


### PR DESCRIPTION
I am trying to [run this exporter on a tiny raspberry pi zero](https://brendonmatheson.com/2020/02/20/monitoring-apc-ups-units-with-prometheus-on-raspberry-pi.html) with 512meg ram and a tiny microSD card to boot.
I was not looking forward to a long wait with `apt get install golang ...` (~350 MB!) just to build the binary.

This GHA workflow will automatically build binaries when a new release is created. I have tested this on my own repo and I was able to pull the binary and run it.

```shell
root@raspberrypi:/opt# lsb_release -a
No LSB modules are available.
Distributor ID: Raspbian
Description:    Raspbian GNU/Linux 11 (bullseye)
Release:        11
Codename:       bullseye
root@raspberrypi:/opt# uname -a
Linux raspberrypi 5.15.32+ #1538 Thu Mar 31 19:37:58 BST 2022 armv6l GNU/Linux
root@raspberrypi:/opt# wget https://github.com/kquinsland/apcupsd_exporter/releases/download/v0.3.1/apcupsd_exporter-v0.3.1-linux-arm.tar.gz  
--2022-07-01 02:55:25--  https://github.com/kquinsland/apcupsd_exporter/releases/download/v0.3.1/apcupsd_exporter-v0.3.1-linux-arm.tar.gz  
Resolving github.com (github.com)... 192.30.255.112  
<...>  
2022-07-01 02:55:27 (3.74 MB/s) - ‘apcupsd_exporter-v0.3.1-linux-arm.tar.gz’ saved [5347842/5347842]  
  
root@raspberrypi:/opt# tar -xzvf apcupsd_exporter-v0.3.1-linux-arm.tar.gz     
apcupsd_exporter  
root@raspberrypi:/opt# chmod +x apcupsd_exporter    
root@raspberrypi:/opt# ./apcupsd_exporter    
2022/07/01 02:55:56 starting apcupsd exporter on ":9162" for server tcp://:3551 
```