### PR TITLE
Build docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build and Push Multi-Arch Docker Image
+name: Docker Build
 
 on:
   workflow_run:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,59 @@
+name: Build and Push Multi-Arch Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: my-go-service
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Step 1: Checkout the code
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Step 2: Set up Docker Buildx for multi-platform builds
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    # Step 3: Log in to GitHub Container Registry (GHCR)
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # Step 4: Extract metadata (tags, labels) for Docker
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+
+    # Step 5: Build and push Docker images to GHCR for multiple architectures
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        platforms: |
+          linux/amd64
+          linux/arm
+          linux/arm64
+        tags: |
+          ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:${{ github.sha }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,9 +1,10 @@
 name: Build and Push Multi-Arch Docker Image
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Linux Test"]
+    types:
+      - completed
   release:
     types: [published]
 
@@ -12,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: my-go-service
+  IMAGE_NAME: apcupsd_exporter
 
 jobs:
   build-and-push:

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17]
+        go-version: [1.21]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
       id: go

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [1.21]
     runs-on: ubuntu-latest
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
       id: go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Use the official Golang image as the build stage
+FROM --platform=$BUILDPLATFORM golang:1.21 AS build
+
+# Set environment variables to build a static binary
+ARG TARGETOS
+ARG TARGETARCH
+ENV CGO_ENABLED=0 \
+    GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH
+
+# Set the working directory
+WORKDIR /app
+
+# Copy go.mod and go.sum, then download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code to the container
+COPY . .
+
+# Build the application from the correct entry point
+RUN go build -o service ./cmd/apcupsd_exporter/main.go
+
+# Use a minimal base image for the final stage
+FROM gcr.io/distroless/static:nonroot
+
+# Set the working directory in the container
+WORKDIR /
+
+# Copy the compiled binary from the build stage
+COPY --from=build /app/service .
+
+# Run the service binary as the container entrypoint
+ENTRYPOINT ["/service"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Usage of ./apcupsd_exporter:
         address for apcupsd exporter (default ":9162")
   -telemetry.path string
         URL path for surfacing collected metrics (default "/metrics")
+  -metrics.system bool
+        set to false to disable emitting system level metrics (default "true")
 ```
 
 ## Running as Docker Container

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d \
   --name apcupsd-exporter \
   --add-host=host.docker.internal:host-gateway \
   ghcr.io/thedebuggedlife/apcupsd_exporter:latest \
-  -apcupsd.addr host.docker.internal:3551
+  -apcupsd.addr=host.docker.internal:3551
 ```
 
 Using Docker Compose:
@@ -45,7 +45,7 @@ services:
     image: ghcr.io/thedebuggedlife/apcupsd_exporter:latest
     restart: unless-stopped
     command:
-      - -apcupsd.addr host.docker.internal:3551
+      - -apcupsd.addr=host.docker.internal:3551
     ports:
       - 9162:9162
     extra_hosts:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# apcupsd_exporter [![Linux Test Status](https://github.com/mdlayher/apcupsd_exporter/workflows/Linux%20Test/badge.svg)](https://github.com/mdlayher/apcupsd_exporter/actions)  [![GoDoc](http://godoc.org/github.com/mdlayher/apcupsd_exporter?status.svg)](http://godoc.org/github.com/mdlayher/apcupsd_exporter)
+# apcupsd_exporter 
+[![Linux Test](https://github.com/thedebuggedlife/apcupsd_exporter/actions/workflows/linux-test.yml/badge.svg?branch=main)](https://github.com/thedebuggedlife/apcupsd_exporter/actions/workflows/linux-test.yml) [![Docker Build](https://github.com/thedebuggedlife/apcupsd_exporter/actions/workflows/docker-build.yml/badge.svg?branch=main)](https://github.com/thedebuggedlife/apcupsd_exporter/actions/workflows/docker-build.yml) [![GoDoc](http://godoc.org/github.com/mdlayher/apcupsd_exporter?status.svg)](http://godoc.org/github.com/mdlayher/apcupsd_exporter)
 
 Command `apcupsd_exporter` provides a Prometheus exporter for the
 [apcupsd](http://www.apcupsd.org/) Network Information Server (NIS). MIT
@@ -19,4 +20,32 @@ Usage of ./apcupsd_exporter:
         address for apcupsd exporter (default ":9162")
   -telemetry.path string
         URL path for surfacing collected metrics (default "/metrics")
+```
+
+## Running as Docker Container
+
+Using Docker Run:
+
+```bash
+docker run -d \
+  -p 9162:9162 \
+  --name apcupsd-exporter \
+  --add-host=host.docker.internal:host-gateway \
+  ghcr.io/thedebuggedlife/apcupsd_exporter:latest \
+  -apcupsd.addr host.docker.internal:3551
+```
+
+Using Docker Compose:
+
+```yaml
+services:
+  apcupsd-exporter:
+    image: ghcr.io/thedebuggedlife/apcupsd_exporter:latest
+    restart: unless-stopped
+    command:
+      - -apcupsd.addr host.docker.internal:3551
+    ports:
+      - 9162:9162
+    extra_hosts:
+      - host.docker.internal:host-gateway
 ```

--- a/cmd/apcupsd_exporter/main.go
+++ b/cmd/apcupsd_exporter/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Unregister default collectors if -metrics.system=false
 	if !*metricsSystem {
 		log.Println("Disabling default system metrics (go_*, process_*, promhttp_*)")
-		prometheus.Unregister(collectors.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+		prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 		prometheus.Unregister(collectors.NewGoCollector())
 	}
 

--- a/cmd/apcupsd_exporter/main.go
+++ b/cmd/apcupsd_exporter/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mdlayher/apcupsd"
 	apcupsdexporter "github.com/mdlayher/apcupsd_exporter"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -33,8 +34,8 @@ func main() {
 	// Unregister default collectors if -metrics.system=false
 	if !*metricsSystem {
 		log.Println("Disabling default system metrics (go_*, process_*, promhttp_*)")
-		prometheus.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-		prometheus.Unregister(prometheus.NewGoCollector())
+		prometheus.Unregister(collectors.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+		prometheus.Unregister(collectors.NewGoCollector())
 	}
 
 	fn := newClient(*apcupsdNetwork, *apcupsdAddr)

--- a/cmd/apcupsd_exporter/main.go
+++ b/cmd/apcupsd_exporter/main.go
@@ -19,6 +19,8 @@ var (
 
 	apcupsdAddr    = flag.String("apcupsd.addr", ":3551", "address of apcupsd Network Information Server (NIS)")
 	apcupsdNetwork = flag.String("apcupsd.network", "tcp", `network of apcupsd Network Information Server (NIS): typically "tcp", "tcp4", or "tcp6"`)
+
+	metricsSystem  = flag.Bool("metrics.system", true, "enable or disable default go, process, and promhttp metrics")
 )
 
 func main() {
@@ -26,6 +28,13 @@ func main() {
 
 	if *apcupsdAddr == "" {
 		log.Fatal("address of apcupsd Network Information Server (NIS) must be specified with '-apcupsd.addr' flag")
+	}
+
+	// Unregister default collectors if -metrics.system=false
+	if !*metricsSystem {
+		log.Println("Disabling default system metrics (go_*, process_*, promhttp_*)")
+		prometheus.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+		prometheus.Unregister(prometheus.NewGoCollector())
 	}
 
 	fn := newClient(*apcupsdNetwork, *apcupsdAddr)


### PR DESCRIPTION
Thank you for this project - I use it on a couple Unraid machines to visualize UPS metrics in Prometheus+Grafana, works great!

I wanted to install it using Docker for better portability. Used a fork for that. This PR includes the related changes in case you're interested in merging.

- GH action to build Docker image for amd64, arm and arm64.
- Upgrade Go to 1.21
- New command-line option to disable default system metrics (I didn't have a use for those)